### PR TITLE
feat: Implement simple print-based fallback for PDF generation

### DIFF
--- a/src/apps/client/src/layouts/MainLayout.jsx
+++ b/src/apps/client/src/layouts/MainLayout.jsx
@@ -1,6 +1,7 @@
 import { Outlet, useParams } from 'react-router-dom';
 import { useBranding } from '@client/hooks/useBranding'
 import PDFDownloadButton from '@shared/components/PDFDownloadButton';
+import '@shared/components/print-styles.css';
 
 export default function MainLayout() {
   const { branding } = useBranding()

--- a/src/shared/components/print-styles.css
+++ b/src/shared/components/print-styles.css
@@ -1,6 +1,6 @@
-@media print, (print-mode: true) {
+@media print {
     /* Hide elements not needed in the PDF */
-    nav, button, .no-print, footer, .pdf-download-container {
+    nav, button, .no-print, footer, .pdf-download-container, header {
       display: none !important;
     }
     
@@ -44,6 +44,9 @@
     body {
       font-size: 12pt;
       line-height: 1.3;
+      -webkit-print-color-adjust: exact !important;
+      print-color-adjust: exact !important;
+      color-adjust: exact !important;
     }
     
     h1 {


### PR DESCRIPTION
- Add print fallback mode when PDF generation fails
- Update button UI to show print vs download icon based on available options
- Simplify print styles for better browser compatibility
- Import print styles directly in the layout component
- Add color adjustment properties for better map/chart printing